### PR TITLE
Preserve Stingray spit effect with hidden visors

### DIFF
--- a/Visors/FCRVisorPatches.cs
+++ b/Visors/FCRVisorPatches.cs
@@ -1,16 +1,30 @@
 ﻿using GameNetcodeStuff;
 using HarmonyLib;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Rumi.FixCameraResolutions.Visors
 {
     public static class FCRVisorPatches
     {
+        static readonly System.Reflection.FieldInfo helmetGoopField = AccessTools.Field(typeof(HUDManager), "helmetGoop");
+        static readonly Dictionary<int, bool> originalRendererStates = new Dictionary<int, bool>();
+        static readonly Dictionary<int, GameObject> overlayObjects = new Dictionary<int, GameObject>();
+        static Mesh? quadMesh;
+
         public static bool disable => FCRPlugin.visorConfig?.disable ?? FCRVisorConfig.dDisable;
 
         [HarmonyPatch(typeof(PlayerControllerB), "Start")]
         [HarmonyPostfix]
         static void PlayerControllerB_Start_Postfix(PlayerControllerB __instance) => UpdatePlayer(__instance);
+
+        [HarmonyPatch(typeof(HUDManager), "DisplaySpitOnHelmet")]
+        [HarmonyPostfix]
+        static void HUDManager_DisplaySpitOnHelmet_Postfix() => SyncOverlayState(GameNetworkManager.Instance?.localPlayerController);
+
+        [HarmonyPatch(typeof(HUDManager), "Update")]
+        [HarmonyPostfix]
+        static void HUDManager_Update_Postfix() => SyncOverlayState(GameNetworkManager.Instance?.localPlayerController);
 
         public static void UpdateAllPlayer()
         {
@@ -19,27 +33,140 @@ namespace Rumi.FixCameraResolutions.Visors
                 UpdatePlayer(players[i]);
         }
 
-        public static void UpdatePlayer(PlayerControllerB player)
+        public static void UpdatePlayer(PlayerControllerB? player)
         {
-            if (player.localVisor != null)
+            if (player?.localVisor == null)
+                return;
+
+            Transform? scavengerHelmet = player.localVisor.Find("ScavengerHelmet");
+            if (scavengerHelmet == null)
+                return;
+
+            // Keep the vanilla visor/goop chain alive, but hide the visor renderers.
+            scavengerHelmet.gameObject.SetActive(true);
+            UpdateHelmetRenderers(scavengerHelmet);
+            EnsureOverlayObject(player);
+            SyncOverlayState(player);
+        }
+
+        static void UpdateHelmetRenderers(Transform scavengerHelmet)
+        {
+            Renderer[] renderers = scavengerHelmet.GetComponentsInChildren<Renderer>(true);
+
+            for (int i = 0; i < renderers.Length; i++)
             {
-                Transform? scavengerHelmet = player.localVisor.Find("ScavengerHelmet");
-                Transform? plane = player.localVisor.Find("ScavengerHelmet/Plane");
+                Renderer renderer = renderers[i];
+                int instanceId = renderer.GetInstanceID();
 
-                if (plane == null)
-                    plane = player.localVisor.Find("Plane");
+                if (!originalRendererStates.ContainsKey(instanceId))
+                    originalRendererStates[instanceId] = renderer.enabled;
 
-                if (scavengerHelmet != null && plane != null)
-                {
-                    //특정 각도에서 안개가 사라지는 요상한 버그 수정
-                    if (disable)
-                        plane.SetParent(player.localVisor);
-                    else
-                        plane.SetParent(scavengerHelmet);
-
-                    scavengerHelmet.gameObject.SetActive(!disable);
-                }
+                renderer.enabled = disable ? false : originalRendererStates[instanceId];
             }
+        }
+
+        static GameObject? GetHelmetGoop()
+        {
+            if (HUDManager.Instance == null || helmetGoopField == null)
+                return null;
+
+            return helmetGoopField.GetValue(HUDManager.Instance) as GameObject;
+        }
+
+        static void EnsureOverlayObject(PlayerControllerB? player)
+        {
+            if (player?.gameplayCamera == null)
+                return;
+
+            int playerId = player.GetInstanceID();
+            if (overlayObjects.TryGetValue(playerId, out GameObject? overlayObject) && overlayObject != null)
+            {
+                UpdateOverlayTransform(player, overlayObject.transform);
+                return;
+            }
+
+            GameObject? helmetGoop = GetHelmetGoop();
+            Renderer? sourceRenderer = helmetGoop != null ? helmetGoop.GetComponentInChildren<Renderer>(true) : null;
+            if (sourceRenderer == null)
+                return;
+
+            overlayObject = new GameObject("FixCameraHelmetGoopOverlay");
+            overlayObject.layer = player.gameplayCamera.gameObject.layer;
+            overlayObject.transform.SetParent(player.gameplayCamera.transform, false);
+
+            MeshFilter meshFilter = overlayObject.AddComponent<MeshFilter>();
+            meshFilter.sharedMesh = GetQuadMesh();
+
+            MeshRenderer meshRenderer = overlayObject.AddComponent<MeshRenderer>();
+            meshRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            meshRenderer.receiveShadows = false;
+            meshRenderer.lightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
+            meshRenderer.reflectionProbeUsage = UnityEngine.Rendering.ReflectionProbeUsage.Off;
+            meshRenderer.motionVectorGenerationMode = MotionVectorGenerationMode.ForceNoMotion;
+            meshRenderer.allowOcclusionWhenDynamic = false;
+            meshRenderer.sharedMaterials = sourceRenderer.sharedMaterials;
+            meshRenderer.enabled = false;
+
+            UpdateOverlayTransform(player, overlayObject.transform);
+            overlayObject.SetActive(false);
+            overlayObjects[playerId] = overlayObject;
+        }
+
+        static void SyncOverlayState(PlayerControllerB? player)
+        {
+            if (player?.gameplayCamera == null)
+                return;
+
+            EnsureOverlayObject(player);
+
+            int playerId = player.GetInstanceID();
+            if (!overlayObjects.TryGetValue(playerId, out GameObject? overlayObject) || overlayObject == null)
+                return;
+
+            GameObject? helmetGoop = GetHelmetGoop();
+            Renderer? sourceRenderer = helmetGoop != null ? helmetGoop.GetComponentInChildren<Renderer>(true) : null;
+            Renderer? overlayRenderer = overlayObject.GetComponent<Renderer>();
+            if (sourceRenderer == null || overlayRenderer == null)
+                return;
+
+            UpdateOverlayTransform(player, overlayObject.transform);
+            overlayRenderer.sharedMaterials = sourceRenderer.sharedMaterials;
+
+            bool showOverlay = disable && helmetGoop != null && helmetGoop.activeInHierarchy;
+            overlayObject.SetActive(showOverlay);
+            overlayRenderer.enabled = showOverlay;
+        }
+
+        static void UpdateOverlayTransform(PlayerControllerB player, Transform overlayTransform)
+        {
+            Camera camera = player.gameplayCamera;
+            float distance = Mathf.Max(camera.nearClipPlane + 0.015f, 0.05f);
+            float height = 2f * Mathf.Tan(camera.fieldOfView * 0.5f * Mathf.Deg2Rad) * distance;
+            float width = height * camera.aspect;
+
+            overlayTransform.localPosition = new Vector3(0f, 0f, distance);
+            overlayTransform.localRotation = Quaternion.identity;
+            overlayTransform.localScale = new Vector3(width * 1.02f, height * 1.02f, 1f);
+        }
+
+        static Mesh? GetQuadMesh()
+        {
+            if (quadMesh != null)
+                return quadMesh;
+
+            GameObject primitive = GameObject.CreatePrimitive(PrimitiveType.Quad);
+
+            try
+            {
+                MeshFilter meshFilter = primitive.GetComponent<MeshFilter>();
+                quadMesh = meshFilter != null ? meshFilter.sharedMesh : null;
+            }
+            finally
+            {
+                Object.DestroyImmediate(primitive);
+            }
+
+            return quadMesh;
         }
 
         internal static void Patch()


### PR DESCRIPTION
## Summary

Fixes the local Stingray spit/goop effect when visor hiding is enabled.

The PR now only changes `Visors/FCRVisorPatches.cs`. The existing config and repatch flow is left as-is.

## Cause

The hidden visor path moved the visor plane and disabled the `ScavengerHelmet` hierarchy. That hides the visor, but the local Stingray spit effect still depends on the vanilla helmet/goop object path.

Because that carrier path was disabled or constrained by the original visor geometry, the effect could disappear or render only inside the old visor opening area.

## Fix

Keep the `ScavengerHelmet` hierarchy active so the vanilla goop update chain can still run.

When hidden visor mode is enabled, hide the original visor renderers instead of disabling the whole hierarchy. Then mirror the helmet goop material onto a small overlay object parented to the local gameplay camera, so the final local spit effect is not clipped by the original visor mesh area.

The overlay state is synced from `DisplaySpitOnHelmet` and `HUDManager.Update`.

## Testing

Not compile-tested locally.

Static checks done against the current `main` file shape:
- hidden visor still patches only when visor hiding is enabled
- existing config/repatch behavior is unchanged
- non-visor rendering paths are not touched
- the old `FCRPlugin.cs` and `FCRVisorConfig.cs` changes were dropped from the final patch

## Notes

This is intentionally kept to one file so the diff is easier to review.

It does not restore the visible visor mesh, change the visor config entry, change the repatch scheduler, or replace the vanilla goop material path with a custom effect.

<img width="2560" height="1440" alt="2026-04-11 180602" src="https://github.com/user-attachments/assets/f2fa2c82-7308-40a2-a16d-dfa54a36dff2" />

